### PR TITLE
Rename model reference to avoid confusion on what is a prompt

### DIFF
--- a/1-chat-models/1-prompt/PromptWithQuarkus.java
+++ b/1-chat-models/1-prompt/PromptWithQuarkus.java
@@ -74,7 +74,7 @@ public class PromptWithQuarkus implements QuarkusApplication {
         String ask(String prompt);
     }
 
-    @RegisterAiService(modelName = "prompt-b")
+    @RegisterAiService(modelName = "for-prompt-b")
     static interface PromptB {
         String ask(String prompt);
     }

--- a/1-chat-models/1-prompt/application.properties
+++ b/1-chat-models/1-prompt/application.properties
@@ -1,5 +1,5 @@
-quarkus.langchain4j.openai.prompt-b.chat-model.log-requests=true
-#quarkus.langchain4j.openai.prompt-b.chat-model.log-responses=true
-quarkus.langchain4j.openai.prompt-b.chat-model.temperature=0.7
-quarkus.langchain4j.openai.prompt-b.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.openai.for-prompt-b.chat-model.log-requests=true
+#quarkus.langchain4j.openai.prompt-b-model.chat-model.log-responses=true
+quarkus.langchain4j.openai.for-prompt-b.chat-model.temperature=0.7
+quarkus.langchain4j.openai.for-prompt-b.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}

--- a/1-chat-models/1-prompt/application.properties
+++ b/1-chat-models/1-prompt/application.properties
@@ -1,5 +1,5 @@
 quarkus.langchain4j.openai.for-prompt-b.chat-model.log-requests=true
-#quarkus.langchain4j.openai.prompt-b-model.chat-model.log-responses=true
+#quarkus.langchain4j.openai.for-prompt-b.chat-model.log-responses=true
 quarkus.langchain4j.openai.for-prompt-b.chat-model.temperature=0.7
 quarkus.langchain4j.openai.for-prompt-b.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}


### PR DESCRIPTION
The reference was prompt-b, I prefer to show that this text is
not "hardwired" to other elements like PromptB the classname.
