### PR TITLE
Remove unnecessary quarkus.http.test-port property

### DIFF
--- a/1-chat-models/2-messages/src/main/resources/application.properties
+++ b/1-chat-models/2-messages/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/1-chat-models/3-manual-memory/src/main/resources/application.properties
+++ b/1-chat-models/3-manual-memory/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/1-chat-models/4-chat-memory/src/main/resources/application.properties
+++ b/1-chat-models/4-chat-memory/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/1-chat-models/5-tokens/src/main/resources/application.properties
+++ b/1-chat-models/5-tokens/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/2-ai-services/1-langchain4j-ai-service-simple/src/main/resources/application.properties
+++ b/2-ai-services/1-langchain4j-ai-service-simple/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/2-ai-services/2-langchain4j-ai-service-messages/src/main/resources/application.properties
+++ b/2-ai-services/2-langchain4j-ai-service-messages/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/2-ai-services/3-langchain4j-ai-service-parameters/src/main/resources/application.properties
+++ b/2-ai-services/3-langchain4j-ai-service-parameters/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/2-ai-services/4-langchain4j-ai-service-structured-output/src/main/resources/application.properties
+++ b/2-ai-services/4-langchain4j-ai-service-structured-output/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/2-ai-services/5-langchain4j-ai-service-chat-memory/src/main/resources/application.properties
+++ b/2-ai-services/5-langchain4j-ai-service-chat-memory/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/3-quarkus-ai-services/1-quarkus-ai-service-simple/src/main/resources/application.properties
+++ b/3-quarkus-ai-services/1-quarkus-ai-service-simple/src/main/resources/application.properties
@@ -6,4 +6,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/5-function-calling/4-function-calling-search-tools/src/main/resources/application.properties
+++ b/5-function-calling/4-function-calling-search-tools/src/main/resources/application.properties
@@ -12,4 +12,3 @@ quarkus.langchain4j.openai.chat-model.timeout=1m
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %test.quarkus.langchain4j.tavily.api-key=change-me
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/7-images/1-image-model/src/main/resources/application.properties
+++ b/7-images/1-image-model/src/main/resources/application.properties
@@ -12,4 +12,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1

--- a/7-images/2-image-model-in-ai-services/src/main/resources/application.properties
+++ b/7-images/2-image-model-in-ai-services/src/main/resources/application.properties
@@ -11,4 +11,3 @@ quarkus.langchain4j.openai.api-key=${OPENAI_API_KEY}
 %test,ollama.quarkus.langchain4j.openai.base-url=http://localhost:11434/v1
 %test,ollama.quarkus.langchain4j.openai.timeout=10m
 %ollama.quarkus.langchain4j.openai.api-key=somesupersecretkey
-quarkus.http.test-port=-1


### PR DESCRIPTION
There is no http extension in these projects, so it only produces an unnecessary warning